### PR TITLE
Refactor to use an adapter pattern

### DIFF
--- a/Fudgefile
+++ b/Fudgefile
@@ -15,7 +15,7 @@ task_group :duplication do
 end
 
 task_group :complexity do
-  task :flog, :exclude => '^\.\/spec\/', :max => 7.7, :average => 5.7, :methods => true
+  task :flog, :exclude => '^\.\/spec\/', :methods => true
 end
 
 build :default do

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Rack middleware to sit in a rails app to put put the current environments log to
 
 To be used in test and development environments to see logs without needing direct access to the box.
 
-This NOT to be used in production like environments.
+:warning: This is *NOT* to be used in production like environments.
 
 Supports Rails 3.x.x and 4.x.x
 
@@ -37,14 +37,14 @@ Inside you rails app. Add the following line to config/development.rb and/or any
 
 The following configuration options are available.
 
-* :path_to_log_file => '/path/to/custom/log'. Defaults to current environments log file if in rails.
-* :lines_to_read => 1000. Defaults to 500.
+* `:path_to_log_file => '/path/to/custom/log'`. Defaults to current environments log file if in rails.
+* `:lines_to_read => 1000`. Defaults to 500.
 
 Example.
 
     config.middleware.use(Logput::Middleware, :lines_to_read => 300, :path_to_log_file => './log/delayed_job')
 
-Start you rails server as normal in the set environemnt. Navigate to /logput e.g. [http://localhost:3000/logput](http://localhost:3000/logput)
+Start your rails server as normal in the set environment. Navigate to /logput e.g. [http://localhost:3000/logput](http://localhost:3000/logput)
 
 ## Contributing
 

--- a/lib/logput.rb
+++ b/lib/logput.rb
@@ -4,4 +4,5 @@ require 'rack'
 # Logput
 module Logput
   autoload :Middleware, 'logput/middleware'
+  autoload :Adapters, 'logput/adapters'
 end

--- a/lib/logput/adapters.rb
+++ b/lib/logput/adapters.rb
@@ -8,12 +8,12 @@ module Logput
     end
 
     # Find a registered adapter
-    # @return [Adapter, nil] An instance of the adapter, or nil
+    # @return [Adapter] An instance of the adapter, or raise an exception
     def self.obtain(logger)
       registered_adapters.each do |_, adapter|
         return adapter.new(logger) if adapter.handles?(logger)
       end
-      return nil
+      raise "#{logger} is not supported."
     end
 
     require 'logput/adapters/base'

--- a/lib/logput/adapters.rb
+++ b/lib/logput/adapters.rb
@@ -1,0 +1,23 @@
+# Logput
+module Logput
+  # Logging Adapters
+  module Adapters
+    # @return [Hash] Currently registered adapters
+    def self.registered_adapters
+      @registered_adapters ||= {}
+    end
+
+    # Find a registered adapter
+    # @return [Adapter, nil] An instance of the adapter, or nil
+    def self.obtain(logger)
+      registered_adapters.each do |_, adapter|
+        return adapter.new(logger) if adapter.handles?(logger)
+      end
+      return nil
+    end
+
+    require 'logput/adapters/base'
+    require 'logput/adapters/logger'
+    require 'logput/adapters/tagged_logging'
+  end
+end

--- a/lib/logput/adapters/base.rb
+++ b/lib/logput/adapters/base.rb
@@ -1,0 +1,34 @@
+# Logput
+module Logput
+  # Logging Adapters
+  module Adapters
+    # Base class from which all adapters inherit
+    class Base
+      # Initialize
+      def initialize(logger)
+        @logger = logger
+      end
+
+      # Registers a new adapter
+      #
+      # @param [Symbol] adapter The name of the adapter
+      def self.register(adapter)
+        raise "Already Registered :#{adapter}" if Logput::Adapters.registered_adapters[adapter]
+        Logput::Adapters.registered_adapters[adapter] = self
+      end
+
+      # Placeholder for handles? method to be overridden when subclassed
+      # @param [Class] logger
+      # @return [Boolean]
+      def self.handles?(logger)
+        raise NotImplementedError
+      end
+
+      # Placeholder for path method to be overridden when subclassed
+      # @return [String] path
+      def path
+        raise NotImplementedError
+      end
+    end
+  end
+end

--- a/lib/logput/adapters/base.rb
+++ b/lib/logput/adapters/base.rb
@@ -18,9 +18,9 @@ module Logput
       end
 
       # Placeholder for handles? method to be overridden when subclassed
-      # @param [Class] logger
+      # @param [Class] _logger
       # @return [Boolean]
-      def self.handles?(logger)
+      def self.handles?(_logger)
         raise NotImplementedError
       end
 

--- a/lib/logput/adapters/logger.rb
+++ b/lib/logput/adapters/logger.rb
@@ -1,0 +1,22 @@
+# Logput
+module Logput
+  # Logging Adapters
+  module Adapters
+    # Logger Adapter
+    class Logger < Base
+      register :logger
+
+      # @param [Class] logger
+      # @return [Boolean]
+      def self.handles?(logger)
+        return false unless logger
+        logger.is_a? ::Logger
+      end
+
+      # @return [String] path
+      def path
+        @logger.instance_variable_get(:@logdev).filename
+      end
+    end
+  end
+end

--- a/lib/logput/adapters/tagged_logging.rb
+++ b/lib/logput/adapters/tagged_logging.rb
@@ -1,0 +1,22 @@
+# Logput
+module Logput
+  # Logging Adapters
+  module Adapters
+    # Active Support Tagged Logging Adapter
+    class TaggedLogging < Base
+      register :tagged_logging
+
+      # @param [Class] logger
+      # @return [Boolean]
+      def self.handles?(logger)
+        return false unless logger
+        logger.is_a? ::ActiveSupport::TaggedLogging
+      end
+
+      # @return [String] path
+      def path
+        @logger.instance_variable_get(:@logger).instance_variable_get(:@log_dest).path
+      end
+    end
+  end
+end

--- a/lib/logput/middleware.rb
+++ b/lib/logput/middleware.rb
@@ -25,7 +25,7 @@ module Logput
     private
 
     def ensure_log_file_exists!
-      raise 'Log file does not exist' unless File.exists? @path_to_log_file
+      raise 'Log file does not exist' unless File.exist? @path_to_log_file
     end
 
     def is_logput?

--- a/lib/logput/middleware.rb
+++ b/lib/logput/middleware.rb
@@ -10,36 +10,48 @@ module Logput
 
     # Call
     def call(env)
-      @path_to_log_file ||= default_path_to_log_file(env)
+      @env = env
+      @path_to_log_file ||= default_path_to_log_file
 
-      raise 'Log file does not exist' unless File.exists? @path_to_log_file
+      ensure_log_file_exists!
 
-      if env['PATH_INFO'] == '/logput'
-        out = `tail -n #{@lines_to_read} #{@path_to_log_file}`
-        [200, {"Content-Type" => "text/html"}, ["<pre>", out, "</pre>"]]
+      if is_logput?
+        generate_output!
       else
-        @app.call(env)
+        @app.call(@env)
       end
     end
 
     private
 
-    def default_path_to_log_file(env)
+    def ensure_log_file_exists!
+      raise 'Log file does not exist' unless File.exists? @path_to_log_file
+    end
+
+    def is_logput?
+      @env['PATH_INFO'] == '/logput'
+    end
+
+    def generate_output!
+      out = `tail -n #{@lines_to_read} #{@path_to_log_file}`
+      [200, {"Content-Type" => "text/html"}, ["<pre>", out, "</pre>"]]
+    end
+
+    def default_path_to_log_file
       raise Exception, 'Must specify path to Rails log file' unless defined? Rails
-      path(logger(env)) || raise(Exception, "#{logger(env).class} not supported.")
+      path || raise(Exception, "#{logger.class} not supported.")
     end
 
-    def logger(env)
-      env['action_dispatch.logger']
+    def logger
+      @env['action_dispatch.logger']
     end
 
-    def path(logger)
-      case logger
-        when ::ActiveSupport::TaggedLogging
-          logger.instance_variable_get(:@logger).instance_variable_get(:@log_dest).path
-        when ::Logger
-          logger.instance_variable_get(:@logdev).filename
-      end
+    def path
+      logger_adapter.path
+    end
+
+    def logger_adapter
+      @logger_adapter ||= Logput::Adapters.obtain(logger)
     end
   end
 end

--- a/lib/logput/middleware.rb
+++ b/lib/logput/middleware.rb
@@ -39,7 +39,7 @@ module Logput
 
     def default_path_to_log_file
       raise Exception, 'Must specify path to Rails log file' unless defined? Rails
-      path || raise(Exception, "#{logger.class} not supported.")
+      path
     end
 
     def logger

--- a/lib/logput/version.rb
+++ b/lib/logput/version.rb
@@ -1,5 +1,5 @@
 # Logput
 module Logput
   # Gem version
-  VERSION = "0.0.3"
+  VERSION = "0.0.4"
 end

--- a/spec/adapters/base_spec.rb
+++ b/spec/adapters/base_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+class UnRegisteredAdapter < Logput::Adapters::Base
+end
+
+describe Logput::Adapters::Base do
+  describe '.register' do
+    after :each do
+      Logput::Adapters.registered_adapters.delete(:test)
+    end
+
+    it 'adds the current adapter to the registry' do
+      expect(Logput::Adapters.registered_adapters[:test]).to eq(nil)
+      UnRegisteredAdapter.register :test
+      expect(Logput::Adapters.registered_adapters[:test]).to eq(UnRegisteredAdapter)
+    end
+  end
+
+  describe '.handles?' do
+    it 'raises a NotImplementedError' do
+      expect {
+        described_class.handles?(double)
+      }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe '#path' do
+    subject { described_class.new(:foo) }
+
+    it 'raises a NotImplementedError' do
+      expect {
+        subject.path
+      }.to raise_error(NotImplementedError)
+    end
+  end
+end

--- a/spec/adapters/logger_spec.rb
+++ b/spec/adapters/logger_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe Logput::Adapters::Logger do
+  describe '.handles?' do
+    it 'returns true when passed a Logger instance' do
+      expect(described_class.handles?(::Logger.new)).to eq(true)
+    end
+
+    it 'returns false when passed anything else' do
+      expect(described_class.handles?(::ActiveSupport::TaggedLogging.new)).to eq(false)
+      expect(described_class.handles?(:foo)).to eq(false)
+    end
+  end
+
+  describe '#path' do
+    let(:path) { './spec/support/test.log' }
+    let(:logger) { ::Logger.new }
+    let(:logdev) { double(:filename => path) }
+
+    before :each do
+      allow(logger).to receive(:instance_variable_get).with(:@logdev).and_return(logdev)
+    end
+
+    subject { described_class.new(logger) }
+
+    it 'returns the correct path' do
+      expect(subject.path).to eq(path)
+    end
+  end
+end

--- a/spec/adapters/tagged_logging_spec.rb
+++ b/spec/adapters/tagged_logging_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe Logput::Adapters::TaggedLogging do
+  describe '.handles?' do
+    it 'returns true when passed an ActiveSupport::TaggedLogging instance' do
+      expect(described_class.handles?(::ActiveSupport::TaggedLogging.new)).to eq(true)
+    end
+
+    it 'returns false when passed anything else' do
+      expect(described_class.handles?(::Logger.new)).to eq(false)
+      expect(described_class.handles?(:foo)).to eq(false)
+    end
+  end
+
+  describe '#path' do
+    let(:path) { './spec/support/test.log' }
+    let(:logger) { ::ActiveSupport::TaggedLogging.new }
+    let(:logvar) { double }
+    let(:logdev) { double(:filename => path) }
+    let(:log_dest) { double(:path => path) }
+
+    before :each do
+      allow(logger).to receive(:instance_variable_get).with(:@logger).and_return(logvar)
+      allow(logvar).to receive(:instance_variable_get).with(:@log_dest).and_return(log_dest)
+    end
+
+    subject { described_class.new(logger) }
+
+    it 'returns the correct path' do
+      expect(subject.path).to eq(path)
+    end
+  end
+end

--- a/spec/adapters_spec.rb
+++ b/spec/adapters_spec.rb
@@ -31,8 +31,10 @@ describe Logput::Adapters do
     end
 
     context 'when no adapter matches' do
-      it 'returns nil' do
-        expect(described_class.obtain(:foo)).to eq(nil)
+      it 'raises a logger not supported exception' do
+        expect {
+          described_class.obtain(:foo)
+        }.to raise_error
       end
     end
   end

--- a/spec/adapters_spec.rb
+++ b/spec/adapters_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+class TestAdapter
+  def initialize(logger); end
+  def self.handles?(logger); false; end
+end
+
+describe Logput::Adapters do
+
+  describe '.registered_adapters' do
+    let(:expected) {{
+      logger: Logput::Adapters::Logger,
+      tagged_logging: Logput::Adapters::TaggedLogging
+    }}
+
+    it 'returns a hash of registered adapters' do
+      expect(described_class.registered_adapters).to eq(expected)
+    end
+  end
+
+  describe '.obtain' do
+    before :each do
+      Logput::Adapters.registered_adapters[:test] = TestAdapter
+    end
+
+    context 'when an adapter matches' do
+      it 'returns an instance of a matching adapter' do
+        allow(TestAdapter).to receive(:handles?).with(:bar).and_return(true)
+        expect(described_class.obtain(:bar)).to be_a(TestAdapter)
+      end
+    end
+
+    context 'when no adapter matches' do
+      it 'returns nil' do
+        expect(described_class.obtain(:foo)).to eq(nil)
+      end
+    end
+  end
+end

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -1,9 +1,5 @@
 require 'spec_helper'
 
-module ActiveSupport; class TaggedLogging; end; end
-class Logger; end
-class Rails; end
-
 describe Logput::Middleware do
   subject{ described_class.new(app, :path_to_log_file => './spec/support/test.log') }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,3 +22,7 @@ RSpec.configure do |config|
 
   config.requires = ['logput']
 end
+
+module ActiveSupport; class TaggedLogging; end; end
+class Logger; end
+class Rails; end


### PR DESCRIPTION
Reduces complexity of `middleware.rb` by extracting out the types of Logger into an adapter pattern. This would easily allow for other types of logger to be added later.
